### PR TITLE
Basic framework for new video transform device

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -42,7 +42,8 @@
       }
     },
     "../..": {
-      "version": "3.10.0",
+      "name": "amazon-chime-sdk-js",
+      "version": "3.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,8 @@ import PingPong from './pingpong/PingPong';
 import PingPongObserver from './pingpongobserver/PingPongObserver';
 import PrefetchOn from './messagingsession/PrefetchOn';
 import PrefetchSortBy from './messagingsession/PrefetchSortBy';
+import PremiumVideoStreamHandler from './premiumvideodevice/PremiumVideoStreamHandler';
+import PremiumVideoTransformDevice from './premiumvideodevice/PremiumVideoTransformDevice';
 import PromiseQueue from './utils/PromiseQueue';
 import PromoteToPrimaryMeetingTask from './task/PromoteToPrimaryMeetingTask';
 import RealtimeAttendeePositionInFrame from './realtimecontroller/RealtimeAttendeePositionInFrame';
@@ -541,6 +543,8 @@ export {
   PingPongObserver,
   PrefetchOn,
   PrefetchSortBy,
+  PremiumVideoStreamHandler,
+  PremiumVideoTransformDevice,
   PromiseQueue,
   PromoteToPrimaryMeetingTask,
   RealtimeAttendeePositionInFrame,

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,8 @@ import PingPong from './pingpong/PingPong';
 import PingPongObserver from './pingpongobserver/PingPongObserver';
 import PrefetchOn from './messagingsession/PrefetchOn';
 import PrefetchSortBy from './messagingsession/PrefetchSortBy';
+import PremiumVideoEffectConfig from './premiumvideodevice/PremiumVideoEffectConfig';
+import PremiumVideoEffectDriver from './premiumvideodevice/PremiumVideoEffectDriver';
 import PremiumVideoStreamHandler from './premiumvideodevice/PremiumVideoStreamHandler';
 import PremiumVideoTransformDevice from './premiumvideodevice/PremiumVideoTransformDevice';
 import PromiseQueue from './utils/PromiseQueue';
@@ -543,6 +545,8 @@ export {
   PingPongObserver,
   PrefetchOn,
   PrefetchSortBy,
+  PremiumVideoEffectConfig,
+  PremiumVideoEffectDriver,
   PremiumVideoStreamHandler,
   PremiumVideoTransformDevice,
   PromiseQueue,

--- a/src/premiumvideodevice/PremiumVideoEffectConfig.ts
+++ b/src/premiumvideodevice/PremiumVideoEffectConfig.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * [[PremiumVideoEffectConfig]] describes the configuration of desired video effects that should be
+ * applied onto a [[PremiumVideoTransformDevice]] via a [[PremiumVideoEffectEngine]]
+ */
+export default interface PremiumVideoEffectConfig {
+    /** Dummy effect for time being -- but will shift video for blur emphasis. */
+    blueShiftEnabled: boolean;
+    /** Dummy effect for time being -- but will shift video for red emphasis. */
+    redShiftEnabled: boolean;
+}

--- a/src/premiumvideodevice/PremiumVideoEffectConfig.ts
+++ b/src/premiumvideodevice/PremiumVideoEffectConfig.ts
@@ -6,8 +6,8 @@
  * applied onto a [[PremiumVideoTransformDevice]] via a [[PremiumVideoEffectEngine]]
  */
 export default interface PremiumVideoEffectConfig {
-    /** Dummy effect for time being -- but will shift video for blur emphasis. */
-    blueShiftEnabled: boolean;
-    /** Dummy effect for time being -- but will shift video for red emphasis. */
-    redShiftEnabled: boolean;
+  /** Dummy effect for time being -- but will shift video for blur emphasis. */
+  blueShiftEnabled: boolean;
+  /** Dummy effect for time being -- but will shift video for red emphasis. */
+  redShiftEnabled: boolean;
 }

--- a/src/premiumvideodevice/PremiumVideoEffectDriver.ts
+++ b/src/premiumvideodevice/PremiumVideoEffectDriver.ts
@@ -1,0 +1,74 @@
+import Logger from "../logger/Logger";
+import PremiumVideoEffectConfig from "./PremiumVideoEffectConfig"
+
+const CHANNEL_COUNT = 4; // The number of channels in a video frame
+const MAX_PIXEL_VAL = 255; // Max pixel value in unsigned 8 bit int space
+
+/**
+ * [[PremiumVideoEffectDriver]] Mechanism that drives the data transformation 
+ * of individual images/frames in order to apply different ML-Based effects.
+ * Current Dummy Effects:
+ *  blue shift
+ *  red shift
+ * Future Effects:
+ *  bg blur
+ *  bg replacement
+ */
+export default class PremiumVideoEffectDriver {
+    constructor(
+        private logger: Logger,
+        private config: PremiumVideoEffectConfig
+    ) {
+        this.logger.info("PremiumVideoEffectDriver Created")
+    }
+
+    /**
+     * Apply a transformation of configured effects onto an input image
+     * @param inputImageData 
+     * @returns transformed image data to be pasted onto output canvas
+     */
+    async apply(inputImageData: ImageData): Promise<ImageData>{
+        console.log('[hunter] b r' + this.config.blueShiftEnabled + ' ' + this.config.redShiftEnabled)
+        const imageElements = inputImageData.width * inputImageData.height
+                                     * CHANNEL_COUNT;
+        let rawOutputData: Uint8ClampedArray = new Uint8ClampedArray(imageElements);
+
+        for (let i = 0; i < imageElements; i++) {
+            if (this.config.redShiftEnabled && i % 4 == 0) {
+                rawOutputData[i] = MAX_PIXEL_VAL;
+            } else if (this.config.blueShiftEnabled && i % 4 == 2) {
+                rawOutputData[i] = MAX_PIXEL_VAL;
+            } else {
+                rawOutputData[i] = inputImageData.data[i];
+            }
+        }
+
+        return new ImageData(rawOutputData, inputImageData.width,
+            inputImageData.height);
+    }
+
+    /**
+     * Enable the Blue Shift Effect
+     * @param enabled 
+     */
+    setBlueShiftState(enabled: boolean): void {
+        this.config.blueShiftEnabled = enabled;
+    }  
+
+    /**
+     * Enable the Red Shift Effect
+     * @param enabled 
+     */
+    setRedShiftState(enabled: boolean): void {
+        this.config.redShiftEnabled = enabled;
+    }
+
+    /**
+     * Get the current [[PremiumVideoEffectConfig]]
+     * @returns the current PremiumVideoEffectConfig
+     */
+    getEffectConfig(): PremiumVideoEffectConfig {
+        return this.config;
+    }
+
+}

--- a/src/premiumvideodevice/PremiumVideoEffectDriver.ts
+++ b/src/premiumvideodevice/PremiumVideoEffectDriver.ts
@@ -1,11 +1,11 @@
-import Logger from "../logger/Logger";
-import PremiumVideoEffectConfig from "./PremiumVideoEffectConfig"
+import Logger from '../logger/Logger';
+import PremiumVideoEffectConfig from './PremiumVideoEffectConfig';
 
 const CHANNEL_COUNT = 4; // The number of channels in a video frame
 const MAX_PIXEL_VAL = 255; // Max pixel value in unsigned 8 bit int space
 
 /**
- * [[PremiumVideoEffectDriver]] Mechanism that drives the data transformation 
+ * [[PremiumVideoEffectDriver]] Mechanism that drives the data transformation
  * of individual images/frames in order to apply different ML-Based effects.
  * Current Dummy Effects:
  *  blue shift
@@ -15,60 +15,53 @@ const MAX_PIXEL_VAL = 255; // Max pixel value in unsigned 8 bit int space
  *  bg replacement
  */
 export default class PremiumVideoEffectDriver {
-    constructor(
-        private logger: Logger,
-        private config: PremiumVideoEffectConfig
-    ) {
-        this.logger.info("PremiumVideoEffectDriver Created")
-    }
+  constructor(private logger: Logger, private config: PremiumVideoEffectConfig) {
+    this.logger.info('PremiumVideoEffectDriver Created');
+  }
 
-    /**
-     * Apply a transformation of configured effects onto an input image
-     * @param inputImageData 
-     * @returns transformed image data to be pasted onto output canvas
-     */
-    async apply(inputImageData: ImageData): Promise<ImageData>{
-        console.log('[hunter] b r' + this.config.blueShiftEnabled + ' ' + this.config.redShiftEnabled)
-        const imageElements = inputImageData.width * inputImageData.height
-                                     * CHANNEL_COUNT;
-        let rawOutputData: Uint8ClampedArray = new Uint8ClampedArray(imageElements);
+  /**
+   * Apply a transformation of configured effects onto an input image
+   * @param inputImageData
+   * @returns transformed image data to be pasted onto output canvas
+   */
+  async apply(inputImageData: ImageData): Promise<ImageData> {
+    const transformData = (currentPixel: number, idx: number) => {
+      if (this.config.redShiftEnabled && idx % CHANNEL_COUNT == 0) {
+        return MAX_PIXEL_VAL;
+      } else if (this.config.blueShiftEnabled && idx % CHANNEL_COUNT == 2) {
+        return MAX_PIXEL_VAL;
+      } else {
+        return currentPixel;
+      }
+    };
+    const rawOutputData: Uint8ClampedArray = inputImageData.data.map((currentPixel, idx) =>
+      transformData(currentPixel, idx)
+    );
 
-        for (let i = 0; i < imageElements; i++) {
-            if (this.config.redShiftEnabled && i % 4 == 0) {
-                rawOutputData[i] = MAX_PIXEL_VAL;
-            } else if (this.config.blueShiftEnabled && i % 4 == 2) {
-                rawOutputData[i] = MAX_PIXEL_VAL;
-            } else {
-                rawOutputData[i] = inputImageData.data[i];
-            }
-        }
+    return new ImageData(rawOutputData, inputImageData.width, inputImageData.height);
+  }
 
-        return new ImageData(rawOutputData, inputImageData.width,
-            inputImageData.height);
-    }
+  /**
+   * Enable the Blue Shift Effect
+   * @param enabled
+   */
+  setBlueShiftState(enabled: boolean): void {
+    this.config.blueShiftEnabled = enabled;
+  }
 
-    /**
-     * Enable the Blue Shift Effect
-     * @param enabled 
-     */
-    setBlueShiftState(enabled: boolean): void {
-        this.config.blueShiftEnabled = enabled;
-    }  
+  /**
+   * Enable the Red Shift Effect
+   * @param enabled
+   */
+  setRedShiftState(enabled: boolean): void {
+    this.config.redShiftEnabled = enabled;
+  }
 
-    /**
-     * Enable the Red Shift Effect
-     * @param enabled 
-     */
-    setRedShiftState(enabled: boolean): void {
-        this.config.redShiftEnabled = enabled;
-    }
-
-    /**
-     * Get the current [[PremiumVideoEffectConfig]]
-     * @returns the current PremiumVideoEffectConfig
-     */
-    getEffectConfig(): PremiumVideoEffectConfig {
-        return this.config;
-    }
-
+  /**
+   * Get the current [[PremiumVideoEffectConfig]]
+   * @returns the current PremiumVideoEffectConfig
+   */
+  getEffectConfig(): PremiumVideoEffectConfig {
+    return this.config;
+  }
 }

--- a/src/premiumvideodevice/PremiumVideoStreamHandler.ts
+++ b/src/premiumvideodevice/PremiumVideoStreamHandler.ts
@@ -1,4 +1,5 @@
 import Logger from "../logger/Logger";
+import PremiumVideoEffectDriver from "./PremiumVideoEffectDriver";
 
 const DEFAULT_FRAMERATE = 15;
 
@@ -27,7 +28,8 @@ export default class PremiumVideoStreamHandler {
     outputMediaStream: MediaStream = new MediaStream();
 
     // Constructor just sets a logger for the object
-    constructor(private logger: Logger) {}
+    constructor(private logger: Logger,
+                private videoEffectDriver: PremiumVideoEffectDriver) {}
  
     getActiveOutputMediaStream(): MediaStream {
         if (this.isOutputMediaStreamActive()) {
@@ -99,6 +101,7 @@ export default class PremiumVideoStreamHandler {
             this.canvasInput.width, this.canvasInput.height);
 
         // Transform input data
+        let transformedImageData = await this.videoEffectDriver.apply(inputImageData);
 
         // Confirm that the output canvas is still matching video frame size
         if (this.canvasOutput.width !== this.videoInput.videoWidth && 
@@ -107,8 +110,8 @@ export default class PremiumVideoStreamHandler {
            this.canvasOutput.height = this.videoInput.videoHeight;
        }
     
-       // Place transformed data onto outp
-        this.outputCtx.putImageData(inputImageData, 0, 0);
+       // Place transformed data onto output canvas
+        this.outputCtx.putImageData(transformedImageData, 0, 0);
 
         if (!this.hasStarted) {
             this.hasStarted = true;

--- a/src/premiumvideodevice/PremiumVideoStreamHandler.ts
+++ b/src/premiumvideodevice/PremiumVideoStreamHandler.ts
@@ -1,0 +1,185 @@
+import Logger from "../logger/Logger";
+
+const DEFAULT_FRAMERATE = 15;
+
+/** @internal */
+interface HTMLCanvasElementWithCaptureStream extends HTMLCanvasElement {
+    // Not in IE, but that's OK.
+    captureStream(frameRate?: number): MediaStream;
+}
+
+export default class PremiumVideoStreamHandler {
+    private framerate: number = DEFAULT_FRAMERATE;
+    private lastTimeOut: ReturnType<typeof setTimeout> | undefined;
+    private hasStarted: boolean = false;
+
+    // Inputs
+    private videoInput: HTMLVideoElement = document.createElement('video') as HTMLVideoElement;
+    private canvasInput: HTMLCanvasElement = document.createElement('canvas');
+    private inputCtx = this.canvasInput.getContext('2d');
+    private inputVideoStream: MediaStream | null = null;
+
+    // Outputs
+    private canvasOutput: HTMLCanvasElementWithCaptureStream = document.createElement(
+        'canvas'
+    ) as HTMLCanvasElementWithCaptureStream;
+    private outputCtx = this.canvasOutput.getContext('2d');
+    outputMediaStream: MediaStream = new MediaStream();
+
+    // Constructor just sets a logger for the object
+    constructor(private logger: Logger) {}
+ 
+    getActiveOutputMediaStream(): MediaStream {
+        if (this.isOutputMediaStreamActive()) {
+            return this.outputMediaStream;
+        }
+        this.outputMediaStream = this.canvasOutput.captureStream(this.framerate);
+        this.cloneInputAudioTracksToOutput();
+        return this.outputMediaStream;
+    }
+
+    stopStream(): void {
+        throw new Error('Method not implemented.');
+    }
+    destroyStream(): void {
+        throw new Error('Method not implemented.');
+    }
+
+    async setInputMediaStream(inputMediaStream: MediaStream | null): Promise<void> {
+        if (!inputMediaStream) {
+            this.stop();
+            return;
+        }
+
+        if (inputMediaStream.getVideoTracks().length === 0) {
+            this.logger.error("No video tracks in input media stream, ignoring");
+            return;
+        }
+
+
+        this.inputVideoStream = inputMediaStream;
+        const settings = this.inputVideoStream.getVideoTracks()[0].getSettings();
+        this.canvasOutput.width = settings.width;
+        this.canvasOutput.height = settings.height;
+        this.videoInput.addEventListener('loadedmetadata', this.process); // this will be the trigger function
+        this.videoInput.srcObject = this.inputVideoStream;
+        // avoid iOS safari full screen video -- not sure what this does
+        this.videoInput.setAttribute('playsinline', 'true');
+        
+        this.videoInput.load();
+        try {
+            await this.videoInput.play();
+        } catch {
+            this.logger.warn('Video element play() overriden by another load()');
+        }
+
+        this.cloneInputAudioTracksToOutput();
+    }
+
+    // WHY IS THE FUNCTION DECLARED LIKE THIS?????
+    process = async (_event:Event): Promise<void> => {
+        if (!this.inputVideoStream) {
+            return;
+        }
+        const processVideoStart = performance.now();
+
+        // Draw the videoInput onto our input canvas
+        if (this.videoInput.videoWidth) {
+            // Match input canvas to same dimensions as our input stream 
+            if (this.canvasInput.width !== this.videoInput.videoWidth || 
+                 this.canvasInput.height !== this.videoInput.videoHeight) {
+                this.canvasInput.width = this.videoInput.videoWidth;
+                this.canvasInput.height = this.videoInput.videoHeight;
+            }
+            this.inputCtx.drawImage(this.videoInput, 0, 0);
+        }
+
+        // Collect out input frame data
+        let inputImageData = this.inputCtx.getImageData(0, 0, 
+            this.canvasInput.width, this.canvasInput.height);
+
+        // Transform input data
+
+        // Confirm that the output canvas is still matching video frame size
+        if (this.canvasOutput.width !== this.videoInput.videoWidth && 
+            this.canvasOutput.height !== this.videoInput.videoHeight) {
+           this.canvasOutput.width = this.videoInput.videoWidth;
+           this.canvasOutput.height = this.videoInput.videoHeight;
+       }
+    
+       // Place transformed data onto outp
+        this.outputCtx.putImageData(inputImageData, 0, 0);
+
+        if (!this.hasStarted) {
+            this.hasStarted = true;
+        }
+
+        // timing to maintain requested fps
+        const processVideoLatency = performance.now() - processVideoStart;
+        //const leave = (1000 * 2) / this.framerate - processVideoLatency; // half fps
+        const nextFrameDelay = Math.max(0, 1000 / this.framerate - processVideoLatency);
+
+        // TODO: use requestAnimationFrame which is more organic and allows browser to conserve resources by its choices.
+        /* @ts-ignore */
+        this.lastTimeout = setTimeout(this.process, nextFrameDelay);
+    }
+
+    stop() {;
+        this.videoInput.removeEventListener('loadedmetadata', this.process)
+        this.videoInput.srcObject = null;
+
+        this.destroyInputMediaAndBuffers();
+
+        // Stop all the output tracks, but don't discard the media stream,
+        // because it's how other parts of the codebase recognize when
+        // a selected stream is part of this transform device.
+        if (this.outputMediaStream) {
+            for (const track of this.outputMediaStream.getVideoTracks()) {
+            track.stop();
+            }
+        }
+
+        // This will prevent the process loop from continuing to call itself
+        if (this.lastTimeOut) {
+            clearTimeout(this.lastTimeOut);
+            this.lastTimeOut = undefined;
+        }
+
+        if (this.hasStarted) {
+            this.hasStarted = false;
+        }
+        
+    }
+
+    private destroyInputMediaAndBuffers() {
+        if (this.inputVideoStream) {
+            for (const track of this.inputVideoStream.getTracks()) {
+              track.stop();
+            }
+        }
+        this.inputVideoStream = null;
+    }
+
+    private cloneInputAudioTracksToOutput(): void {
+        if (!this.isOutputMediaStreamActive() || this.inputVideoStream === null) {
+            this.logger.info('Not cloning input audio tracks to output, do not have media streams ready');
+            return; // Just wait for `getActiveOutputMediaStream`
+        }
+
+        // Remove current audio tracks from output
+        for (const audioTrack of this.outputMediaStream.getAudioTracks()) {
+            this.logger.info(`Removing audio track ${audioTrack.id} from output stream`);
+            this.outputMediaStream.removeTrack(audioTrack);
+        }
+
+        // Add new audio track to output
+        for (const audioTrack of this.inputVideoStream.getAudioTracks()) {
+            this.logger.info(`Adding audio track ${audioTrack.id} to output stream`);
+            this.outputMediaStream.addTrack(audioTrack);
+        }
+    }
+
+    private isOutputMediaStreamActive(): boolean {
+        return this.outputMediaStream && this.outputMediaStream.active;
+    }
+}

--- a/src/premiumvideodevice/PremiumVideoStreamHandler.ts
+++ b/src/premiumvideodevice/PremiumVideoStreamHandler.ts
@@ -1,188 +1,202 @@
-import Logger from "../logger/Logger";
-import PremiumVideoEffectDriver from "./PremiumVideoEffectDriver";
+import Logger from '../logger/Logger';
+import PremiumVideoEffectDriver from './PremiumVideoEffectDriver';
 
 const DEFAULT_FRAMERATE = 15;
+const MIN_FRAME_DELAY = 0;
+const MS_PER_SECOND = 1000;
 
 /** @internal */
 interface HTMLCanvasElementWithCaptureStream extends HTMLCanvasElement {
-    // Not in IE, but that's OK.
-    captureStream(frameRate?: number): MediaStream;
+  // Not in IE, but that's OK.
+  captureStream(frameRate?: number): MediaStream;
 }
 
+/**
+ * [[PremiumVideoStreamHandler]] Will be used to handle the stream associated with the
+ * device in the DefaultVideoTransformDevice. It is responsible for triggering the
+ * action in the PremiumVideoEffectDriver and processing the transformed frames onto
+ * the output canvas
+ */
 export default class PremiumVideoStreamHandler {
-    private framerate: number = DEFAULT_FRAMERATE;
-    private lastTimeOut: ReturnType<typeof setTimeout> | undefined;
-    private hasStarted: boolean = false;
+  private framerate: number = DEFAULT_FRAMERATE;
+  private lastTimeOut: ReturnType<typeof setTimeout> | undefined;
 
-    // Inputs
-    private videoInput: HTMLVideoElement = document.createElement('video') as HTMLVideoElement;
-    private canvasInput: HTMLCanvasElement = document.createElement('canvas');
-    private inputCtx = this.canvasInput.getContext('2d');
-    private inputVideoStream: MediaStream | null = null;
+  // Inputs
+  private videoInput: HTMLVideoElement = document.createElement('video') as HTMLVideoElement;
+  private canvasInput: HTMLCanvasElement = document.createElement('canvas');
+  private inputCtx = this.canvasInput.getContext('2d');
+  private inputVideoStream: MediaStream | null = null;
 
-    // Outputs
-    private canvasOutput: HTMLCanvasElementWithCaptureStream = document.createElement(
-        'canvas'
-    ) as HTMLCanvasElementWithCaptureStream;
-    private outputCtx = this.canvasOutput.getContext('2d');
-    outputMediaStream: MediaStream = new MediaStream();
+  // Outputs
+  private canvasOutput: HTMLCanvasElementWithCaptureStream = document.createElement(
+    'canvas'
+  ) as HTMLCanvasElementWithCaptureStream;
+  private outputCtx = this.canvasOutput.getContext('2d');
+  outputMediaStream: MediaStream = new MediaStream();
 
-    // Constructor just sets a logger for the object
-    constructor(private logger: Logger,
-                private videoEffectDriver: PremiumVideoEffectDriver) {}
- 
-    getActiveOutputMediaStream(): MediaStream {
-        if (this.isOutputMediaStreamActive()) {
-            return this.outputMediaStream;
-        }
-        this.outputMediaStream = this.canvasOutput.captureStream(this.framerate);
-        this.cloneInputAudioTracksToOutput();
-        return this.outputMediaStream;
+  // Constructor just sets a logger for the object
+  constructor(private logger: Logger, private videoEffectDriver: PremiumVideoEffectDriver) {}
+
+  /**
+   * If existing, return the output media stream. If not existing, create and return
+   * a media stream off of our output canvas
+   * @returns MediaStream
+   */
+  getActiveOutputMediaStream(): MediaStream {
+    if (this.isOutputMediaStreamActive()) {
+      return this.outputMediaStream;
+    }
+    this.outputMediaStream = this.canvasOutput.captureStream(this.framerate);
+    this.cloneInputAudioTracksToOutput();
+    return this.outputMediaStream;
+  }
+
+  /**
+   * Configure an inputMediaStream so that it is placed onto a HTML video element and
+   * configure our transformation function (apply) to process as our stream continues
+   * loading new data
+   */
+  async setInputMediaStream(inputMediaStream: MediaStream | null): Promise<void> {
+    if (!inputMediaStream) {
+      this.stop();
+      return;
     }
 
-    stopStream(): void {
-        throw new Error('Method not implemented.');
-    }
-    destroyStream(): void {
-        throw new Error('Method not implemented.');
+    if (inputMediaStream.getVideoTracks().length === 0) {
+      this.logger.error('No video tracks in input media stream, ignoring');
+      return;
     }
 
-    async setInputMediaStream(inputMediaStream: MediaStream | null): Promise<void> {
-        if (!inputMediaStream) {
-            this.stop();
-            return;
-        }
+    this.inputVideoStream = inputMediaStream;
+    await this.startVideoOnMediaStream(inputMediaStream);
+    this.cloneInputAudioTracksToOutput();
+  }
 
-        if (inputMediaStream.getVideoTracks().length === 0) {
-            this.logger.error("No video tracks in input media stream, ignoring");
-            return;
-        }
+  private async startVideoOnMediaStream(inputMediaStream: MediaStream): Promise<void> {
+    const settings = this.inputVideoStream.getVideoTracks()[0].getSettings();
+    this.canvasOutput.width = settings.width;
+    this.canvasOutput.height = settings.height;
+    this.videoInput.addEventListener('loadedmetadata', this.process); // this will be the trigger function
+    this.videoInput.srcObject = this.inputVideoStream;
+    // avoid iOS safari full screen video -- not sure what this does
+    this.videoInput.setAttribute('playsinline', 'true');
 
+    this.videoInput.load();
+    try {
+      await this.videoInput.play();
+    } catch {
+      this.logger.warn('Video element play() overriden by another load()');
+    }
+    return;
+  }
 
-        this.inputVideoStream = inputMediaStream;
-        const settings = this.inputVideoStream.getVideoTracks()[0].getSettings();
-        this.canvasOutput.width = settings.width;
-        this.canvasOutput.height = settings.height;
-        this.videoInput.addEventListener('loadedmetadata', this.process); // this will be the trigger function
-        this.videoInput.srcObject = this.inputVideoStream;
-        // avoid iOS safari full screen video -- not sure what this does
-        this.videoInput.setAttribute('playsinline', 'true');
-        
-        this.videoInput.load();
-        try {
-            await this.videoInput.play();
-        } catch {
-            this.logger.warn('Video element play() overriden by another load()');
-        }
+  /**
+   * Transform a singular frame from the input stream to apply desired
+   * video effects. Then place the output image data onto our output canvas
+   * configured with an output stream
+   */
+  process = async (_event: Event): Promise<void> => {
+    if (!this.inputVideoStream) {
+      return;
+    }
+    const processVideoStart = performance.now();
 
-        this.cloneInputAudioTracksToOutput();
+    // Draw the videoInput onto our input canvas
+    if (this.videoInput.videoWidth) {
+      this.canvasInput.width = this.videoInput.videoWidth;
+      this.canvasInput.height = this.videoInput.videoHeight;
+      this.inputCtx.drawImage(this.videoInput, 0, 0);
     }
 
-    // WHY IS THE FUNCTION DECLARED LIKE THIS?????
-    process = async (_event:Event): Promise<void> => {
-        if (!this.inputVideoStream) {
-            return;
-        }
-        const processVideoStart = performance.now();
+    // Collect out input frame data
+    let inputImageData = this.inputCtx.getImageData(
+      0,
+      0,
+      this.canvasInput.width,
+      this.canvasInput.height
+    );
 
-        // Draw the videoInput onto our input canvas
-        if (this.videoInput.videoWidth) {
-            // Match input canvas to same dimensions as our input stream 
-            if (this.canvasInput.width !== this.videoInput.videoWidth || 
-                 this.canvasInput.height !== this.videoInput.videoHeight) {
-                this.canvasInput.width = this.videoInput.videoWidth;
-                this.canvasInput.height = this.videoInput.videoHeight;
-            }
-            this.inputCtx.drawImage(this.videoInput, 0, 0);
-        }
+    // Transform input data
+    let transformedImageData = await this.videoEffectDriver.apply(inputImageData);
 
-        // Collect out input frame data
-        let inputImageData = this.inputCtx.getImageData(0, 0, 
-            this.canvasInput.width, this.canvasInput.height);
-
-        // Transform input data
-        let transformedImageData = await this.videoEffectDriver.apply(inputImageData);
-
-        // Confirm that the output canvas is still matching video frame size
-        if (this.canvasOutput.width !== this.videoInput.videoWidth && 
-            this.canvasOutput.height !== this.videoInput.videoHeight) {
-           this.canvasOutput.width = this.videoInput.videoWidth;
-           this.canvasOutput.height = this.videoInput.videoHeight;
-       }
-    
-       // Place transformed data onto output canvas
-        this.outputCtx.putImageData(transformedImageData, 0, 0);
-
-        if (!this.hasStarted) {
-            this.hasStarted = true;
-        }
-
-        // timing to maintain requested fps
-        const processVideoLatency = performance.now() - processVideoStart;
-        //const leave = (1000 * 2) / this.framerate - processVideoLatency; // half fps
-        const nextFrameDelay = Math.max(0, 1000 / this.framerate - processVideoLatency);
-
-        // TODO: use requestAnimationFrame which is more organic and allows browser to conserve resources by its choices.
-        /* @ts-ignore */
-        this.lastTimeout = setTimeout(this.process, nextFrameDelay);
+    // Confirm that the output canvas is still matching video frame size
+    if (
+      this.canvasOutput.width !== this.videoInput.videoWidth &&
+      this.canvasOutput.height !== this.videoInput.videoHeight
+    ) {
+      this.canvasOutput.width = this.videoInput.videoWidth;
+      this.canvasOutput.height = this.videoInput.videoHeight;
     }
 
-    stop() {;
-        this.videoInput.removeEventListener('loadedmetadata', this.process)
-        this.videoInput.srcObject = null;
+    // Place transformed data onto output canvas
+    this.outputCtx.putImageData(transformedImageData, 0, 0);
 
-        this.destroyInputMediaAndBuffers();
+    // timing to maintain requested fps
+    const processVideoLatency = performance.now() - processVideoStart;
+    const nextFrameDelay = Math.max(MIN_FRAME_DELAY, MS_PER_SECOND / this.framerate - processVideoLatency);
 
-        // Stop all the output tracks, but don't discard the media stream,
-        // because it's how other parts of the codebase recognize when
-        // a selected stream is part of this transform device.
-        if (this.outputMediaStream) {
-            for (const track of this.outputMediaStream.getVideoTracks()) {
-            track.stop();
-            }
-        }
+    // TODO: use requestAnimationFrame which is more organic and allows browser to conserve resources by its choices.
+    /* @ts-ignore */
+    this.lastTimeout = setTimeout(this.process, nextFrameDelay);
+  };
 
-        // This will prevent the process loop from continuing to call itself
-        if (this.lastTimeOut) {
-            clearTimeout(this.lastTimeOut);
-            this.lastTimeOut = undefined;
-        }
+  /**
+   * Stop invoking our transformation function and stop the video tracks associated
+   * with our output media stream
+   */
+  stop() {
+    this.videoInput.removeEventListener('loadedmetadata', this.process);
+    this.videoInput.srcObject = null;
 
-        if (this.hasStarted) {
-            this.hasStarted = false;
-        }
-        
+    this.destroyInputMediaAndBuffers();
+
+    // Stop all the output tracks, but don't discard the media stream,
+    // because it's how other parts of the codebase recognize when
+    // a selected stream is part of this transform device.
+    this.outputMediaStream?.getTracks().map(track => track.stop());
+
+    // This will prevent the process loop from continuing to call itself
+    if (this.lastTimeOut) {
+      clearTimeout(this.lastTimeOut);
+      this.lastTimeOut = undefined;
+    }
+  }
+
+  /**
+   * Stop the video tracks associated with our input media stream and remove
+   * reference to input source
+   */
+  private destroyInputMediaAndBuffers() {
+    this.inputVideoStream?.getTracks().map(track => track.stop());
+    this.inputVideoStream = null;
+  }
+
+  /**
+   * Copy over the audio tracks from our input stream into our output stream
+   */
+  private cloneInputAudioTracksToOutput(): void {
+    if (!this.isOutputMediaStreamActive() || this.inputVideoStream === null) {
+      this.logger.info('Not cloning input audio tracks to output, do not have media streams ready');
+      return; // Just wait for `getActiveOutputMediaStream`
     }
 
-    private destroyInputMediaAndBuffers() {
-        if (this.inputVideoStream) {
-            for (const track of this.inputVideoStream.getTracks()) {
-              track.stop();
-            }
-        }
-        this.inputVideoStream = null;
+    // Remove current audio tracks from output
+    for (const audioTrack of this.outputMediaStream.getAudioTracks()) {
+      this.logger.info(`Removing audio track ${audioTrack.id} from output stream`);
+      this.outputMediaStream.removeTrack(audioTrack);
     }
 
-    private cloneInputAudioTracksToOutput(): void {
-        if (!this.isOutputMediaStreamActive() || this.inputVideoStream === null) {
-            this.logger.info('Not cloning input audio tracks to output, do not have media streams ready');
-            return; // Just wait for `getActiveOutputMediaStream`
-        }
-
-        // Remove current audio tracks from output
-        for (const audioTrack of this.outputMediaStream.getAudioTracks()) {
-            this.logger.info(`Removing audio track ${audioTrack.id} from output stream`);
-            this.outputMediaStream.removeTrack(audioTrack);
-        }
-
-        // Add new audio track to output
-        for (const audioTrack of this.inputVideoStream.getAudioTracks()) {
-            this.logger.info(`Adding audio track ${audioTrack.id} to output stream`);
-            this.outputMediaStream.addTrack(audioTrack);
-        }
+    // Add new audio track to output
+    for (const audioTrack of this.inputVideoStream.getAudioTracks()) {
+      this.logger.info(`Adding audio track ${audioTrack.id} to output stream`);
+      this.outputMediaStream.addTrack(audioTrack);
     }
+  }
 
-    private isOutputMediaStreamActive(): boolean {
-        return this.outputMediaStream && this.outputMediaStream.active;
-    }
+  /**
+   * Return boolean representing status of our output media stream being active
+   */
+  private isOutputMediaStreamActive(): boolean {
+    return this.outputMediaStream && this.outputMediaStream.active;
+  }
 }

--- a/src/premiumvideodevice/PremiumVideoTransformDevice.ts
+++ b/src/premiumvideodevice/PremiumVideoTransformDevice.ts
@@ -1,0 +1,67 @@
+import Device from '../devicecontroller/Device';
+import VideoTransformDevice from '../devicecontroller/VideoTransformDevice';
+import Logger from '../logger/Logger';
+import PremiumVideoStreamHandler from './PremiumVideoStreamHandler';
+
+export default class PremiumVideoTransformDevice implements VideoTransformDevice {
+    private inputMediaStream: MediaStream;
+    private premiumVideoStreamHandler: PremiumVideoStreamHandler;
+
+    constructor(
+        private logger: Logger,
+        private device: Device,
+    ) {
+        // initialize the stream handler
+        this.premiumVideoStreamHandler = new PremiumVideoStreamHandler(logger);
+    }
+
+    async stop(): Promise<void> {
+        if (this.inputMediaStream) {
+            for (const track of this.inputMediaStream.getVideoTracks()) {
+                track.stop();
+            }
+        }
+        this.inputMediaStream = null;
+    }
+
+    async intrinsicDevice(): Promise<Device> {
+        return this.device;
+    }
+    
+    async transformStream(mediaStream?: MediaStream): Promise<MediaStream> {
+        await this.premiumVideoStreamHandler.setInputMediaStream(mediaStream);
+        this.inputMediaStream = mediaStream
+        return this.premiumVideoStreamHandler.getActiveOutputMediaStream();
+    }
+    
+    onOutputStreamDisconnect(): void {
+        this.logger.info('DefaultVideoTransformDevice: detach stopping input media stream');
+        
+        const deviceIsMediaStream = this.device && (this.device as MediaStream).id;
+
+        // Turn off the camera, unless device is a MediaStream
+        if (!deviceIsMediaStream) {
+            if (this.inputMediaStream) {
+                for (const track of this.inputMediaStream.getVideoTracks()) {
+                    track.stop();
+                }
+            }
+        }
+    }
+
+    get outputMediaStream(): MediaStream {
+        return this.premiumVideoStreamHandler.outputMediaStream;
+    }
+
+    chooseNewInnerDevice(newDevice: Device): PremiumVideoTransformDevice {
+        const newPremiumTransformDevice = new PremiumVideoTransformDevice(
+            this.logger, 
+            newDevice
+        );
+        return newPremiumTransformDevice;
+    }
+    
+    getInnerDevice(): Device {
+        return this.device;
+    }
+}

--- a/src/premiumvideodevice/PremiumVideoTransformDevice.ts
+++ b/src/premiumvideodevice/PremiumVideoTransformDevice.ts
@@ -2,6 +2,7 @@ import Device from '../devicecontroller/Device';
 import VideoTransformDevice from '../devicecontroller/VideoTransformDevice';
 import Logger from '../logger/Logger';
 import PremiumVideoStreamHandler from './PremiumVideoStreamHandler';
+import PremiumVideoEffectDriver from "./PremiumVideoEffectDriver";
 
 export default class PremiumVideoTransformDevice implements VideoTransformDevice {
     private inputMediaStream: MediaStream;
@@ -10,9 +11,11 @@ export default class PremiumVideoTransformDevice implements VideoTransformDevice
     constructor(
         private logger: Logger,
         private device: Device,
+        private videoEffectDriver: PremiumVideoEffectDriver,
     ) {
         // initialize the stream handler
-        this.premiumVideoStreamHandler = new PremiumVideoStreamHandler(logger);
+        this.premiumVideoStreamHandler = new PremiumVideoStreamHandler(logger,
+            videoEffectDriver);
     }
 
     async stop(): Promise<void> {
@@ -56,7 +59,8 @@ export default class PremiumVideoTransformDevice implements VideoTransformDevice
     chooseNewInnerDevice(newDevice: Device): PremiumVideoTransformDevice {
         const newPremiumTransformDevice = new PremiumVideoTransformDevice(
             this.logger, 
-            newDevice
+            newDevice,
+            this.videoEffectDriver
         );
         return newPremiumTransformDevice;
     }

--- a/src/premiumvideodevice/PremiumVideoTransformDevice.ts
+++ b/src/premiumvideodevice/PremiumVideoTransformDevice.ts
@@ -2,70 +2,90 @@ import Device from '../devicecontroller/Device';
 import VideoTransformDevice from '../devicecontroller/VideoTransformDevice';
 import Logger from '../logger/Logger';
 import PremiumVideoStreamHandler from './PremiumVideoStreamHandler';
-import PremiumVideoEffectDriver from "./PremiumVideoEffectDriver";
+import PremiumVideoEffectDriver from './PremiumVideoEffectDriver';
 
+/**
+ * [[PremiumVideoTransformDevice]] will allow us to transform a regular device
+ * into a format that will allow us to intercept it's MediaStream via a
+ * [[PremiumVideoStreamHandler]] and apply frame-level effects via a
+ * [[PremiumVideoEffectDriver]]
+ */
 export default class PremiumVideoTransformDevice implements VideoTransformDevice {
-    private inputMediaStream: MediaStream;
-    private premiumVideoStreamHandler: PremiumVideoStreamHandler;
+  private inputMediaStream: MediaStream;
+  private premiumVideoStreamHandler: PremiumVideoStreamHandler;
 
-    constructor(
-        private logger: Logger,
-        private device: Device,
-        private videoEffectDriver: PremiumVideoEffectDriver,
-    ) {
-        // initialize the stream handler
-        this.premiumVideoStreamHandler = new PremiumVideoStreamHandler(logger,
-            videoEffectDriver);
-    }
+  constructor(
+    private logger: Logger,
+    private device: Device,
+    private videoEffectDriver: PremiumVideoEffectDriver
+  ) {
+    // initialize the stream handler
+    this.premiumVideoStreamHandler = new PremiumVideoStreamHandler(logger, videoEffectDriver);
+  }
 
-    async stop(): Promise<void> {
-        if (this.inputMediaStream) {
-            for (const track of this.inputMediaStream.getVideoTracks()) {
-                track.stop();
-            }
-        }
-        this.inputMediaStream = null;
+  /**
+   * remove access to a media stream and stop all running video tracks
+   */
+  async stop(): Promise<void> {
+    if (this.inputMediaStream) {
+      for (const track of this.inputMediaStream.getVideoTracks()) {
+        track.stop();
+      }
     }
+    this.inputMediaStream = null;
+  }
 
-    async intrinsicDevice(): Promise<Device> {
-        return this.device;
-    }
-    
-    async transformStream(mediaStream?: MediaStream): Promise<MediaStream> {
-        await this.premiumVideoStreamHandler.setInputMediaStream(mediaStream);
-        this.inputMediaStream = mediaStream
-        return this.premiumVideoStreamHandler.getActiveOutputMediaStream();
-    }
-    
-    onOutputStreamDisconnect(): void {
-        this.logger.info('DefaultVideoTransformDevice: detach stopping input media stream');
-        
-        const deviceIsMediaStream = this.device && (this.device as MediaStream).id;
+  /**
+   * return the associated intrinsic device of the [[PremiumVideoTransformDevice]]
+   *
+   */
+  async intrinsicDevice(): Promise<Device> {
+    return this.device;
+  }
 
-        // Turn off the camera, unless device is a MediaStream
-        if (!deviceIsMediaStream) {
-            if (this.inputMediaStream) {
-                for (const track of this.inputMediaStream.getVideoTracks()) {
-                    track.stop();
-                }
-            }
-        }
-    }
+  /**
+   * Replace whatever input stream we were previously using and start the configured
+   * effect processes in the [[PremiumVideoStreamHandler]]
+   */
+  async transformStream(mediaStream?: MediaStream): Promise<MediaStream> {
+    await this.premiumVideoStreamHandler.setInputMediaStream(mediaStream);
+    this.inputMediaStream = mediaStream;
+    return this.premiumVideoStreamHandler.getActiveOutputMediaStream();
+  }
 
-    get outputMediaStream(): MediaStream {
-        return this.premiumVideoStreamHandler.outputMediaStream;
-    }
+  /**
+   * When our output stream disconnects, we must also stop observing on the input stream
+   */
+  onOutputStreamDisconnect(): void {
+    this.logger.info('DefaultVideoTransformDevice: detach stopping input media stream');
 
-    chooseNewInnerDevice(newDevice: Device): PremiumVideoTransformDevice {
-        const newPremiumTransformDevice = new PremiumVideoTransformDevice(
-            this.logger, 
-            newDevice,
-            this.videoEffectDriver
-        );
-        return newPremiumTransformDevice;
+    const deviceIsMediaStream = this.device && (this.device as MediaStream).id;
+
+    // Turn off the camera, unless device is a MediaStream
+    if (!deviceIsMediaStream && this.inputMediaStream) {
+      this.inputMediaStream.getVideoTracks().map(track => track.stop());
     }
-    
-    getInnerDevice(): Device {
-        return this.device;
-    }
+  }
+
+  /**
+   * Return the output media stream from the [[PremiumVideoStreamHandler]]
+   */
+  get outputMediaStream(): MediaStream {
+    return this.premiumVideoStreamHandler.outputMediaStream;
+  }
+
+  /**
+   * Swap out the inner device associated with the existing [[PremiumVideoTransformDevice]]
+   * while also saving the associated assets in the videoEffectDriver
+   */
+  chooseNewInnerDevice(newDevice: Device): PremiumVideoTransformDevice {
+    return new PremiumVideoTransformDevice(this.logger, newDevice, this.videoEffectDriver);
+  }
+
+  /**
+   * Return the current inner device
+   */
+  getInnerDevice(): Device {
+    return this.device;
+  }
 }


### PR DESCRIPTION
**Basic framework for new video transform device**

**Description of changes:**
I have added the basic framework for a PremiumVideoTransformDevice. This is a new type of device that will be used to support the new  ml based video features. This pull request does not currently interface with any of the web-assembly we will eventually incorporate (into PremiumVideoEffectDriver). For now, PremiumVideoEffectDriver implements two dummy features in raw JS (blue or red shift).

**Testing:**
Tested in meetingV2.ts demo application

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Implemented in demo app. The new video transform device is operating alongside the default video transform device (eventually we will get around to removing the default version).

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

